### PR TITLE
Add leading slash after confirming username

### DIFF
--- a/lua/cmp-plugins/init.lua
+++ b/lua/cmp-plugins/init.lua
@@ -81,7 +81,8 @@ function setup(_opts)
 		elseif incompleteUser then
 			local users = {}
 			for _, value in pairs(repos._map) do
-				table.insert(users, { label = value, detail = "https://github.com/" .. value })
+				table.insert(users, { label = value, insertText = value.."/",
+					word = value, detail = "https://github.com/" .. value })
 			end
 			callback({ items = users, isIncomplete = table.getn(users) ~= 1 })
 		else


### PR DESCRIPTION
Confirming a username will add a leading slash because you probably want to select a repository after selecting the username. However, selecting a username without confirming it will not add the leading slash.